### PR TITLE
Add support for passing the login name and real name (gecos) to check…

### DIFF
--- a/lib/Data/Password/passwdqc.pm
+++ b/lib/Data/Password/passwdqc.pm
@@ -104,14 +104,8 @@ sub _build_params {
 
 sub validate_password {
     my $self = shift;
-    my ($new_pass, $old_pass) = @_;
 
-    my $reason;
-    if (@_ > 1) {
-        $reason = password_check($self->_params, $new_pass, $old_pass); 
-    } else {
-        $reason = password_check($self->_params, $new_pass); 
-    }
+    my $reason = password_check($self->_params, @_);
 
     if ($reason) {
         $self->reason($reason);
@@ -250,6 +244,8 @@ disable this feature.
 
   $is_valid = $pwdqc->validate_password('new password');
   $is_valid = $pwdqc->validate_password('new password', 'old password');
+  $is_valid = $pwdqc->validate_password('new password', 'old password', 'username');
+  $is_valid = $pwdqc->validate_password('new password', 'old password', 'username', 'real name');
   print $pwdqc->reason if not $is_valid;
 
 Checks passphrase quality. Returns a true value on success. If the check

--- a/passwdqc.xs
+++ b/passwdqc.xs
@@ -20,12 +20,25 @@ password_generate(const char *packed_params)
 }
 
 SV *
-password_check(const char *packed_params, const char *new_pass, const char *old_pass)
+password_check(const char *packed_params, const char *new_pass, const char *old_pass, const char *pw_name, const char *pw_gecos)
 {
     const char *reason;
     const passwdqc_params_qc_t *params = (passwdqc_params_qc_t *)packed_params;
 
-    reason = passwdqc_check(params, new_pass, old_pass, NULL);
+    /* this is inspired by what passwdqc does on non-unix platforms */
+    struct passwd fake_pw, *pw;
+    memset(&fake_pw, 0, sizeof(fake_pw));
+    fake_pw.pw_name  = pw_name ? (char *)pw_name : "";
+    fake_pw.pw_gecos = pw_gecos ? (char *)pw_gecos : "";
+    fake_pw.pw_dir   = "";
+    if (pw_name != NULL || pw_gecos != NULL) {
+        pw = &fake_pw;
+    }
+    else {
+        pw = NULL;
+    }
+
+    reason = passwdqc_check(params, new_pass, old_pass, pw);
 
     if (!reason)
         return &PL_sv_undef;
@@ -47,10 +60,32 @@ password_check (packed_params, new_pass, ...)
         const char * packed_params
         const char * new_pass
     CODE:
-        if (items > 2)
-            RETVAL = password_check(packed_params, new_pass, (char *)SvPV_nolen(ST(2)));
-        else
-            RETVAL = password_check(packed_params, new_pass, NULL);
+        switch (items) {
+            case 5:
+                RETVAL = password_check(packed_params, new_pass,
+                            SvOK(ST(2)) ? (char *)SvPV_nolen(ST(2)) : NULL,
+                            SvOK(ST(3)) ? (char *)SvPV_nolen(ST(3)) : NULL,
+                            SvOK(ST(4)) ? (char *)SvPV_nolen(ST(4)) : NULL);
+                break;
+            case 4:
+                RETVAL = password_check(packed_params, new_pass,
+                            SvOK(ST(2)) ? (char *)SvPV_nolen(ST(2)) : NULL,
+                            SvOK(ST(3)) ? (char *)SvPV_nolen(ST(3)) : NULL,
+                            NULL);
+                break;
+            case 3:
+                RETVAL = password_check(packed_params, new_pass,
+                            SvOK(ST(2)) ? (char *)SvPV_nolen(ST(2)) : NULL,
+                            NULL,
+                            NULL);
+                break;
+            case 2:
+                RETVAL = password_check(packed_params, new_pass, NULL, NULL, NULL);
+                break;
+            default:
+                croak("password_check() called with too few arguments!");
+                break;
+        }
     OUTPUT:
         RETVAL
 

--- a/t/default_policy.t
+++ b/t/default_policy.t
@@ -13,6 +13,9 @@ ok($pwdqc->validate_password('cheek6mirror_Wheat', ''));
 ok(!$pwdqc->validate_password('joke_river7Pale', '5joke_6river7Pale'));
 is($pwdqc->reason, 'is based on the old one');
 
+ok(!$pwdqc->validate_password('joke_river7Pale', '5joke_6river7Pale', '5joke'));
+is($pwdqc->reason, 'is based on the old one');
+
 ok(!$pwdqc->validate_password('cheek6mirror_Wheat', 'cheek6mirror_Wheat'));
 is($pwdqc->reason, 'is the same as the old one');
 
@@ -33,5 +36,16 @@ is($pwdqc->reason, 'not enough different characters or classes for this length')
 
 ok(!$pwdqc->validate_password('%+whitehat'));
 is($pwdqc->reason, 'not enough different characters or classes for this length');
+
+ok(!$pwdqc->validate_password('hard apple cider bagel', undef, "hard apple"));
+is($pwdqc->reason, 'based on personal login information');
+
+ok(!$pwdqc->validate_password('hard apple cider bagel', undef, undef, "hard apple"));
+is($pwdqc->reason, 'based on personal login information');
+
+ok(!$pwdqc->validate_password('joke_river7Pale', undef, 'joke_river'));
+is($pwdqc->reason, 'based on personal login information');
+ok(!$pwdqc->validate_password('joke_river7Pale', undef, 'jane summon', scalar reverse 'joke_river'));
+is($pwdqc->reason, 'based on personal login information');
 
 done_testing;


### PR DESCRIPTION
…_password

passwdqc can block passwords based on the username (and gecos name).

This patch adds two optional arguments to check_password()
that allow passing this information in.

I updated the documentation and added a few test cases -- all the tests
pass.